### PR TITLE
-d64 not available e.g. in Java 11

### DIFF
--- a/cmdi-validator-tool/src/main/bin/cmdi-validator.sh
+++ b/cmdi-validator-tool/src/main/bin/cmdi-validator.sh
@@ -28,8 +28,10 @@ if [ -d ${DIRNAME}/endorsed ]; then
     done
 fi
 
-VM_OPTS=""
-if java -version 2>&1 | grep -q -i '64-bit'; then
-  VM_OPTS="-d64 $VM_OPTS"
+if [ `uname -s` = "SunOS" ]; then
+    # VM_OPTS=""  # uncomment to start "clean"
+    if java -version 2>&1 | grep -q -i '64-bit'; then
+        VM_OPTS="-d64 $VM_OPTS"
+    fi
 fi
 exec java ${VM_OPTS} -cp "${CP}" eu.clarin.cmdi.validator.tool.CMDIValidatorTool "$@"


### PR DESCRIPTION
... and it was only ever effective on Solaris anyway.  I suggest to only use `-d64` when on Solaris.

https://stackoverflow.com/a/32007151
http://www.oracle.com/technetwork/java/hotspotfaq-138619.html#64bit_layering